### PR TITLE
Switch to default dnsPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Switch `dnsPolicy` to `Default` to allow running the pod when coreDNS is still not healthy.
+
 ## [1.1.8-gs5] - 2022-03-21
 
 ### Added

--- a/helm/azure-cloud-node-manager-app/templates/daemonset.yaml
+++ b/helm/azure-cloud-node-manager-app/templates/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
         runAsGroup: 0
       serviceAccountName: {{ .Values.name }}
       hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
+      dnsPolicy: Default
       tolerations:
       - operator: "Exists"
       containers:


### PR DESCRIPTION
Switched to Default dns policy to make the pod start when coredns is still not running (chicken-egg problem).
