### PR TITLE
Disable PSPs for k8s 1.25 and newer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Disable PSPs for k8s 1.25 and newer.
+
 ## [1.24.6-gs1] - 2022-12-21
 
 - Fix resources in yaml. it was defined twice

--- a/helm/azure-cloud-node-manager-app/templates/psp.yaml
+++ b/helm/azure-cloud-node-manager-app/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -31,3 +32,4 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: true
+{{- end }}


### PR DESCRIPTION
in k8s 1.25 there is no PodSecurityPolicy

this PR disables the PSP for 1.25