### PR TITLE
Upgrade Chart apiVersion to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `Chart.yaml` `apiVersion` from `v1` to `v2` , this is required by `HelmRelease`
+
 ## [1.24.18-gs1] - 2023-05-03
 
 ### Changed

--- a/helm/azure-cloud-node-manager-app/Chart.yaml
+++ b/helm/azure-cloud-node-manager-app/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 1.24.18
 description: A Helm chart to run Azure Cloud Node Manager
 icon: https://s.giantswarm.io/app-icons/azure/1/dark.svg


### PR DESCRIPTION
Towards giantswarm/roadmap#2271

with v1 when the chart is used through a flux helmRelease the VPA is not installed when the conditional CAPABILITIEs.HAS check is used for rendering
