### PR TITLE
Add switch for PolicyExceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add a switch for PolicyExceptions to be able to disable them in CAPZ.
+
 ## [1.24.18-gs4] - 2023-11-28
 
 ### Added

--- a/helm/azure-cloud-node-manager-app/templates/pss-exceptions.yaml
+++ b/helm/azure-cloud-node-manager-app/templates/pss-exceptions.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployPolicyExceptions }}
 apiVersion: kyverno.io/v2alpha1
 kind: PolicyException
 metadata:
@@ -38,3 +39,4 @@ spec:
         - {{ .Release.Namespace }}
         names:
         - {{ .Values.name }}*
+{{- end }}

--- a/helm/azure-cloud-node-manager-app/values.yaml
+++ b/helm/azure-cloud-node-manager-app/values.yaml
@@ -29,3 +29,5 @@ verticalPodAutoscaler:
 global:
   podSecurityStandards:
     enforced: false
+
+deployPolicyExceptions: true


### PR DESCRIPTION
We have a circular dependency in CAPZ now. This app depends on `kyverno` because of PolicyExceptions. `kyverno` depends on `chart-operator`, that depends on `Cilium` and this app because of taints.  We decided to add core policies to kyverno app. See https://github.com/giantswarm/kyverno-app/pull/313

I didn't remove PolicyExceptions completely since this app is also used in vintage. 

Here is the discussion about where to add the exceptions.  https://gigantic.slack.com/archives/C02FL4EAADD/p1701181092993249?thread_ts=1696497100.521439&cid=C02FL4EAADD